### PR TITLE
Upgrade PHPUnit to 9.6 and update PHP minimum version to 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,13 @@
     "keywords": ["eep"],
     "license": "LGPL",
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=7.3",
         "evenement/evenement": "1.0 - 2.0",
         "react/event-loop": "0.2 - 0.5"
     },
     "require-dev": {
         "ext-pcntl": "*",
-		"phpunit/phpunit": "3.7.*"
+		"phpunit/phpunit": "^9.6.33"
     },
     "autoload": {
         "psr-0": { "React\\EEP": "src" }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,12 +3,8 @@
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="true"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="./tests/bootstrap.php"
 >
     <testsuites>

--- a/tests/React/EEP/Clock/CountingTest.php
+++ b/tests/React/EEP/Clock/CountingTest.php
@@ -2,7 +2,7 @@
 
 namespace React\EEP\Clock;
 
-class CountingTest extends \PHPUnit_Framework_TestCase
+class CountingTest extends \PHPUnit\Framework\TestCase
 {
     /** @test */
     public function clockShouldIncrement() {

--- a/tests/React/EEP/Clock/WallTest.php
+++ b/tests/React/EEP/Clock/WallTest.php
@@ -2,7 +2,7 @@
 
 namespace React\EEP\Clock;
 
-class WallTest extends \PHPUnit_Framework_TestCase
+class WallTest extends \PHPUnit\Framework\TestCase
 {
     /** @test */
     public function clockShouldIncrement() {

--- a/tests/React/EEP/Stats/AllTest.php
+++ b/tests/React/EEP/Stats/AllTest.php
@@ -2,7 +2,7 @@
 
 namespace React\EEP\Stats;
 
-class AllTest extends \PHPUnit_Framework_TestCase
+class AllTest extends \PHPUnit\Framework\TestCase
 {
     /** @test */
     public function allShouldBeTheMin() {

--- a/tests/React/EEP/Stats/CountTest.php
+++ b/tests/React/EEP/Stats/CountTest.php
@@ -2,7 +2,7 @@
 
 namespace React\EEP\Stats;
 
-class CountTest extends \PHPUnit_Framework_TestCase
+class CountTest extends \PHPUnit\Framework\TestCase
 {
     /** @test */
     public function countShouldCount() {

--- a/tests/React/EEP/Stats/MaxTest.php
+++ b/tests/React/EEP/Stats/MaxTest.php
@@ -2,7 +2,7 @@
 
 namespace React\EEP\Stats;
 
-class MaxTest extends \PHPUnit_Framework_TestCase
+class MaxTest extends \PHPUnit\Framework\TestCase
 {
     /** @test */
     public function maxShouldBeTheMin() {

--- a/tests/React/EEP/Stats/MeanTest.php
+++ b/tests/React/EEP/Stats/MeanTest.php
@@ -2,7 +2,7 @@
 
 namespace React\EEP\Stats;
 
-class MeanTest extends \PHPUnit_Framework_TestCase
+class MeanTest extends \PHPUnit\Framework\TestCase
 {
     /** @test */
     public function averageOfTwoNumbersShouldBeHalf() {

--- a/tests/React/EEP/Stats/MinTest.php
+++ b/tests/React/EEP/Stats/MinTest.php
@@ -2,7 +2,7 @@
 
 namespace React\EEP\Stats;
 
-class MinTest extends \PHPUnit_Framework_TestCase
+class MinTest extends \PHPUnit\Framework\TestCase
 {
     /** @test */
     public function minShouldBeTheMin() {

--- a/tests/React/EEP/Stats/StdevTest.php
+++ b/tests/React/EEP/Stats/StdevTest.php
@@ -2,7 +2,7 @@
 
 namespace React\EEP\Stats;
 
-class StdevTest extends \PHPUnit_Framework_TestCase
+class StdevTest extends \PHPUnit\Framework\TestCase
 {
     /** @test */
     public function calculateStdevAccurately() {
@@ -10,12 +10,12 @@ class StdevTest extends \PHPUnit_Framework_TestCase
       $stdev->init();
       $stdev->accumulate(1);
       $stdev->accumulate(1);
-      $this->assertEquals(0, $stdev->emit(), "", 0.01);
+      $this->assertEqualsWithDelta(0, $stdev->emit(), 0.01);
       $stdev->init();
       $stdev->accumulate(5);
       $stdev->accumulate(7);
       $stdev->accumulate(9);
-      $this->assertEquals(2, $stdev->emit(), "", 0.01);
+      $this->assertEqualsWithDelta(2, $stdev->emit(), 0.01);
     }
     
     /** @test */
@@ -26,6 +26,6 @@ class StdevTest extends \PHPUnit_Framework_TestCase
       $stdev->accumulate(7);
       $stdev->accumulate(9);
       $stdev->compensate(5);
-      $this->assertEquals(1.41421, $stdev->emit(), "", 0.01);
+      $this->assertEqualsWithDelta(1.41421, $stdev->emit(), 0.01);
     }
 }

--- a/tests/React/EEP/Stats/SumTest.php
+++ b/tests/React/EEP/Stats/SumTest.php
@@ -2,7 +2,7 @@
 
 namespace React\EEP\Stats;
 
-class SumTest extends \PHPUnit_Framework_TestCase
+class SumTest extends \PHPUnit\Framework\TestCase
 {
     /** @test */
     public function sumUpSomeNumbers() {

--- a/tests/React/EEP/Stats/VarianceTest.php
+++ b/tests/React/EEP/Stats/VarianceTest.php
@@ -2,7 +2,7 @@
 
 namespace React\EEP\Stats;
 
-class VarianceTest extends \PHPUnit_Framework_TestCase
+class VarianceTest extends \PHPUnit\Framework\TestCase
 {
     /** @test */
     public function calculateVarianceAccurately() {
@@ -10,12 +10,12 @@ class VarianceTest extends \PHPUnit_Framework_TestCase
       $vars->init();
       $vars->accumulate(1);
       $vars->accumulate(1);
-      $this->assertEquals(0, $vars->emit(), "", 0.01);
+      $this->assertEqualsWithDelta(0, $vars->emit(), 0.01);
       $vars->init();
       $vars->accumulate(5);
       $vars->accumulate(7);
       $vars->accumulate(9);
-      $this->assertEquals(4, $vars->emit(), "", 0.01);
+      $this->assertEqualsWithDelta(4, $vars->emit(), 0.01);
     }
     
     /** @test */
@@ -26,6 +26,6 @@ class VarianceTest extends \PHPUnit_Framework_TestCase
       $vars->accumulate(7);
       $vars->accumulate(9);
       $vars->compensate(5);
-      $this->assertEquals(2, $vars->emit(), "", 0.01);
+      $this->assertEqualsWithDelta(2, $vars->emit(), 0.01);
     }
 }

--- a/tests/React/EEP/TestFn.php
+++ b/tests/React/EEP/TestFn.php
@@ -6,7 +6,7 @@ use React\EEP\Aggregator;
 
 class TestFn implements Aggregator {
   private $test, $data, $has_emit;
-  public function __construct(\PHPUnit_Framework_TestCase $test) {
+  public function __construct(\PHPUnit\Framework\TestCase $test) {
     $this->test = $test;
     $this->data = null;
     $this->has_emit = 0;

--- a/tests/React/EEP/Window/MonotonicTest.php
+++ b/tests/React/EEP/Window/MonotonicTest.php
@@ -5,7 +5,7 @@ namespace React\EEP\Window;
 use React\EEP\Clock\Counting;
 use React\EEP\TestFn;
 
-class MonotonicTest extends \PHPUnit_Framework_TestCase
+class MonotonicTest extends \PHPUnit\Framework\TestCase
 {
     /** @test */
     public function triggerOnlyOnTick() {

--- a/tests/React/EEP/Window/PeriodicTest.php
+++ b/tests/React/EEP/Window/PeriodicTest.php
@@ -5,7 +5,7 @@ namespace React\EEP\Window;
 use React\EEP\Clock\Counting;
 use React\EEP\TestFn;
 
-class PeriodicTest extends \PHPUnit_Framework_TestCase
+class PeriodicTest extends \PHPUnit\Framework\TestCase
 {
     /** @test */
     public function triggerOnlyOnTick() {

--- a/tests/React/EEP/Window/SlidingTest.php
+++ b/tests/React/EEP/Window/SlidingTest.php
@@ -5,7 +5,7 @@ namespace React\EEP\Window;
 use React\EEP\Clock\Counting;
 use React\EEP\TestFn;
 
-class SlidingTest extends \PHPUnit_Framework_TestCase
+class SlidingTest extends \PHPUnit\Framework\TestCase
 {
     /** @test */
     public function windowShouldSlide() {

--- a/tests/React/EEP/Window/TumblingTest.php
+++ b/tests/React/EEP/Window/TumblingTest.php
@@ -5,7 +5,7 @@ namespace React\EEP\Window;
 use React\EEP\Clock\Counting;
 use React\EEP\TestFn;
 
-class TumblingTest extends \PHPUnit_Framework_TestCase
+class TumblingTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test  


### PR DESCRIPTION
## Summary
This PR modernizes the test suite by upgrading PHPUnit from version 3.7 to 9.6.33 and updating the minimum PHP version requirement from 5.3.2 to 7.3.

## Key Changes
- **PHPUnit Upgrade**: Updated all test class base classes from `\PHPUnit_Framework_TestCase` to `\PHPUnit\Framework\TestCase` (modern namespaced syntax)
- **Assertion Method Updates**: Replaced deprecated `assertEquals()` calls with `assertEqualsWithDelta()` for floating-point comparisons in Stdev and Variance tests
- **PHP Version Requirement**: Updated `composer.json` to require PHP >= 7.3 (from >= 5.3.2)
- **PHPUnit Configuration**: Cleaned up `phpunit.xml` by removing deprecated configuration options:
  - Removed `convertErrorsToExceptions`
  - Removed `convertNoticesToExceptions`
  - Removed `convertWarningsToExceptions`
  - Removed `syntaxCheck`

## Implementation Details
- All 14 test classes were updated to use the modern PHPUnit namespace
- The `TestFn` helper class was also updated to accept the modern `\PHPUnit\Framework\TestCase` type hint
- Floating-point assertion calls were modernized to use the more appropriate `assertEqualsWithDelta()` method with the delta parameter moved to the third position (PHPUnit 9 signature)

https://claude.ai/code/session_01RZSDna2v6huvDDECskHChN